### PR TITLE
Enable Docker build with config supplied as env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,20 @@ WORKDIR /usr/local/yugastore
 # Install app dependencies.
 #
 
+# Install jq for parsing env vars to congfig
+ENV JQ_VERSION='1.5'
+
+RUN wget --no-check-certificate https://raw.githubusercontent.com/stedolan/jq/master/sig/jq-release.key -O /tmp/jq-release.key && \
+    wget --no-check-certificate https://raw.githubusercontent.com/stedolan/jq/master/sig/v${JQ_VERSION}/jq-linux64.asc -O /tmp/jq-linux64.asc && \
+    wget --no-check-certificate https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 -O /tmp/jq-linux64 && \
+    gpg --import /tmp/jq-release.key && \
+    gpg --verify /tmp/jq-linux64.asc /tmp/jq-linux64 && \
+    cp /tmp/jq-linux64 /usr/bin/jq && \
+    chmod +x /usr/bin/jq && \
+    rm -f /tmp/jq-release.key && \
+    rm -f /tmp/jq-linux64.asc && \
+    rm -f /tmp/jq-linux64
+
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
 # where available (npm@5+)
 COPY package*.json ./

--- a/bin/start-for-crossplane.sh
+++ b/bin/start-for-crossplane.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+cd /usr/local/yugastore
+
+config_tmpl='{
+  "DB_HOST": $db_host,
+  "APP_HOST": $app_host,
+  "APP_PORT": $app_port
+}'
+
+jq \
+--arg db_host "$DB_HOST" \
+--arg app_host "$APP_HOST" \
+--arg app_port "$APP_PORT" \
+-n "$config_tmpl" > config.json
+
+# Init the database.
+node models/yugabyte/db_init.js
+
+# Start the rest service
+npm start


### PR DESCRIPTION
Allows for user to create a k8s deployment and supply the config as environment variables. This is useful if the yugabyte db nodes do not have the same name as the quickstart demo. An example deployment could look as follows:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  namespace: rook-yugastore
  name: yugastore
spec:
  selector:
    matchLabels:
      app: yugastore
  template:
    metadata:
      labels:
        app: yugastore
    spec:
      containers:
        - name: yugastore
          image: yugabytedb/yugastore:latest
          imagePullPolicy: Always
          command: ["/usr/local/yugastore/bin/start-for-crossplane.sh"]
          env:
          - name: DB_HOST
            value: "yb-tserver-hello-ybdb-cluster-1.yb-tservers-hello-ybdb-cluster.rook-yugabytedb.svc.cluster.local"
          - name: APP_HOST
            value: "localhost"
          - name: APP_PORT
            value: "3001"
          ports:
            - containerPort: 3001
              name: yugastore
```

This is especially useful when deploying Yugastore with Crossplane or with Rook directly. Documentation on how to utilize this will follow in a subsequent PR.